### PR TITLE
Remove client secret due to redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ It uses the specified refresh token to generate an access token for uploading.
 
 Your tokens client id
 
-### `client-secret`
-
-Your tokens client secret
-
 ### `refresh-token`
 
 Google developer refresh token
@@ -38,7 +34,6 @@ uses: Klemensas/chrome-extension-upload-action@$VERSION
 with:
   refresh-token: 'xxxxxxxxxxxxxxxxxxxxxx'
   client-id: 'xxxxxxxxxxxxx'
-  client-secret: 'xxxxxxxxxxxx'
   file-name: './extension.zip'
   app-id: 'xzc12xzc21cx23'
   publish: true

--- a/action.yml
+++ b/action.yml
@@ -13,9 +13,6 @@ inputs:
   client-id:
     description: Token client id
     required: true
-  client-secret:
-    description: Token client secret
-    required: true
   file-name:
     description: Name of zipped target upload file
     required: true
@@ -28,7 +25,6 @@ runs:
   args:
     - ${{ inputs.refresh-token }}
     - ${{ inputs.client-id }}
-    - ${{ inputs.client-secret }}
     - ${{ inputs.file-name }}
     - ${{ inputs.app-id }}
     - ${{ inputs.publish }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,6 @@ token=`curl \
 -d '{
 	"refresh_token": "'$1'",
 	"client_id": "'$2'",
-	"client_secret": "'$3'",
 	"grant_type": "refresh_token"
 }' \
 -X POST \
@@ -24,8 +23,8 @@ status=`curl \
 -H "Authorization: Bearer $token" \
 -H "x-goog-api-version: 2" \
 -X PUT \
--T $4 \
--v https://www.googleapis.com/upload/chromewebstore/v1.1/items/$5 \
+-T $3 \
+-v https://www.googleapis.com/upload/chromewebstore/v1.1/items/$4 \
 | \
 jq -r '.uploadState'`
 
@@ -34,7 +33,7 @@ then
   exit 1
 fi
 
-if [ $6 == true ] #publish
+if [ $5 == true ] #publish
 then
   publish=`curl \
   --silent \
@@ -43,8 +42,8 @@ then
   -H "Authorization: Bearer $token" \
   -H "x-goog-api-version: 2" \
   -X POST \
-  -T $4 \
-  -v https://www.googleapis.com/upload/chromewebstore/v1.1/items/$5/publish \
+  -T $3 \
+  -v https://www.googleapis.com/upload/chromewebstore/v1.1/items/$4/publish \
   -d publishTarget=default \
   | \
   jq -r '.publishState'`


### PR DESCRIPTION
As proposed in the title, one could remove the client secret as it is not needed anymore if you set the O-Auth Client to Chrome App.

Like you can see, I removed the redundant client secret like it is also proposed in https://github.com/DrewML/chrome-webstore-upload/pull/46. Also tested it myself, the access token generation works like before.

